### PR TITLE
Remove stray center tags

### DIFF
--- a/public2/hometempl.html
+++ b/public2/hometempl.html
@@ -7,7 +7,6 @@
     <link href="/rss.xml" rel="feed" type="application/rss+xml" title="Benjojo's Blog">
     <title>Benjojo's Blog</title>
 </head>
-<center>
 <body style= "background-color: #FFF">
     <table border="0" cellpadding="0" cellspacing="0" style="background-color: #DDD" width="95%">
         <tr>
@@ -80,6 +79,5 @@
             </td>
         </tr>
     </table><br>
-    <center>
 </body>
 </html>


### PR DESCRIPTION
Hi
These stray `<center>` tags start the body before the `<body>` tag and break not-so-lenient parsers (like Feeder - an android RSS reader)