### PR TITLE
Add discovery link for the RSS feed

### DIFF
--- a/public2/hometempl.html
+++ b/public2/hometempl.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="/main.css?2018" rel="stylesheet" type="text/css">
     <link href="/rss.xml" rel="feed" type="application/rss+xml" title="Benjojo's Blog">
+    <link href="/rss.xml" rel="alternate" type="application/rss+xml" title="Benjojo's Blog">
     <link href="https://benjojo.co.uk/u/benjojo" rel="me">
     <title>Benjojo's Blog</title>
 </head>


### PR DESCRIPTION
the pagetempl template already has the discovery link using rel=alternate, but it is missing on the homepage